### PR TITLE
refactor(formatting): Allow hugging if all arguments start in same row

### DIFF
--- a/crates/roughly/src/format.rs
+++ b/crates/roughly/src/format.rs
@@ -334,16 +334,19 @@ fn traverse(
 
             let is_multiline = !same_line(node, node);
             let is_empty = node.child_count() == 2;
-            let start_row = node.start_position().row;
-            let mut hug = true;
-            let _ = tree::for_each_child(cursor, |_, child, field_name, _| {
-                if let Some("argument" | "parameter") = field_name {
-                    hug &= child
-                        .child_by_field_name("value")
-                        .is_some_and(|value| value.start_position().row == start_row);
-                };
-                Ok::<_, ()>(())
-            });
+
+            let hug = if kind == "arguments" {
+                let start_row = node.start_position().row;
+                node.children_by_field_name("argument", &mut node.walk())
+                    .last()
+                    .is_none_or(|argument| {
+                        argument
+                            .child_by_field_name("value")
+                            .is_some_and(|value| value.start_position().row == start_row)
+                    })
+            } else {
+                false
+            };
 
             tree::for_each_child(cursor, |i, child, field_name, cursor| {
                 let maybe_prev = child.prev_sibling();

--- a/crates/roughly/src/format.rs
+++ b/crates/roughly/src/format.rs
@@ -334,13 +334,16 @@ fn traverse(
 
             let is_multiline = !same_line(node, node);
             let is_empty = node.child_count() == 2;
-            let hug = node.child_count() == 3
-                && node
-                    .child_by_field_name("argument")
-                    .is_some_and(|argument| {
-                        argument.child_count() == 1
-                            && argument.child(0).unwrap().kind() == "braced_expression"
-                    });
+            let start_row = node.start_position().row;
+            let mut hug = true;
+            let _ = tree::for_each_child(cursor, |_, child, field_name, _| {
+                if let Some("argument" | "parameter") = field_name {
+                    hug &= child
+                        .child_by_field_name("value")
+                        .is_some_and(|value| value.start_position().row == start_row);
+                };
+                Ok::<_, ()>(())
+            });
 
             tree::for_each_child(cursor, |i, child, field_name, cursor| {
                 let maybe_prev = child.prev_sibling();
@@ -358,6 +361,7 @@ fn traverse(
                         }
                         "comma" => {
                             if is_multiline
+                                && !hug
                                 && (maybe_prev
                                     .is_none_or(|prev| ["comment", "comma"].contains(&prev.kind()))
                                     || i == 1)
@@ -383,7 +387,7 @@ fn traverse(
                                 if is_multiline && !hug {
                                     newline(out);
                                 }
-                            } else if is_multiline {
+                            } else if is_multiline && !hug {
                                 newlines(out, child, maybe_prev);
                             } else {
                                 space(out);

--- a/crates/roughly/tests/snapshots/test_format__call-10.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-10.snap
@@ -1,0 +1,15 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn(arg)\n\n    \tfn(arg\n        )\n\n    \tfn(\n        arg)\n\n    \tfn(\n        arg\n        )\n    \"#}).unwrap()"
+---
+fn(arg)
+
+fn(arg)
+
+fn(
+  arg
+)
+
+fn(
+  arg
+)

--- a/crates/roughly/tests/snapshots/test_format__call-11.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-11.snap
@@ -1,0 +1,15 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn({ body })\n\n    \tfn({ body }\n        )\n\n    \tfn(\n        { body })\n\n    \tfn(\n        { body }\n        )\n    \"#}).unwrap()"
+---
+fn({ body })
+
+fn({ body })
+
+fn(
+  { body }
+)
+
+fn(
+  { body }
+)

--- a/crates/roughly/tests/snapshots/test_format__call-12.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-12.snap
@@ -1,0 +1,23 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn({\n            body\n        })\n\n    \tfn({\n            body\n        }\n        )\n\n    \tfn(\n        {\n            body\n        })\n\n    \tfn(\n        {\n            body\n        }\n        )\n    \"#}).unwrap()"
+---
+fn({
+  body
+})
+
+fn({
+  body
+})
+
+fn(
+  {
+    body
+  }
+)
+
+fn(
+  {
+    body
+  }
+)

--- a/crates/roughly/tests/snapshots/test_format__call-13.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-13.snap
@@ -1,0 +1,23 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n        fn({ body; body })\n        fn({ body;\n        body })\n        fn({ body;\n        body }, arg)\n        fn(a = { body;\n        body }, arg)\n    \"#}).unwrap()"
+---
+fn({ body; body })
+fn({
+  body
+  body
+})
+fn(
+  {
+    body
+    body
+  },
+  arg
+)
+fn(
+  a = {
+    body
+    body
+  },
+  arg
+)

--- a/crates/roughly/tests/snapshots/test_format__call-14.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-14.snap
@@ -1,8 +1,10 @@
 ---
 source: crates/roughly/tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n    \tfn(arg1, fn(\n        ))\n\n    \tfn(arg1, {\n            body\n        })\n\n    \tfn(arg1, arg2 = value, function() {\n            body\n        })\n\n    \tfn(arg1, arg2 = value, if(condition) {\n            body\n        })\n    \"#}).unwrap()"
+expression: "format_str(indoc!\n{r#\"\n    \tfn(arg1, fn(\n        ))\n\n    \tfn(arg1, arg2 = fn(\n        ))\n\n    \tfn(arg1, {\n            body\n        })\n\n    \tfn(arg1, arg2 = value, function() {\n            body\n        })\n\n    \tfn(arg1, arg2 = value, if(condition) {\n            body\n        })\n    \"#}).unwrap()"
 ---
 fn(arg1, fn())
+
+fn(arg1, arg2 = fn())
 
 fn(arg1, {
   body

--- a/crates/roughly/tests/snapshots/test_format__call-14.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-14.snap
@@ -1,0 +1,17 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn(arg1, fn(\n        ))\n\n    \tfn(arg1, {\n            body\n        })\n\n    \tfn(arg1, arg2 = value, function() {\n            body\n        })\n\n    \tfn(arg1, arg2 = value, if(condition) {\n            body\n        })\n    \"#}).unwrap()"
+---
+fn(arg1, fn())
+
+fn(arg1, {
+  body
+})
+
+fn(arg1, arg2 = value, function() {
+  body
+})
+
+fn(arg1, arg2 = value, if (condition) {
+  body
+})

--- a/crates/roughly/tests/snapshots/test_format__call-15.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-15.snap
@@ -1,0 +1,21 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn(fn(arg\n        ))\n\n    \tfn(fn(\n        arg))\n\n    \tfn(fn(\n        arg\n        ))\n\n    \tfn(fn(fn(\n            arg\n        )))\n\n    \tfn(arg = fn(arg =fn(\n            arg\n        )))\n    \"#}).unwrap()"
+---
+fn(fn(arg))
+
+fn(fn(
+  arg
+))
+
+fn(fn(
+  arg
+))
+
+fn(fn(fn(
+  arg
+)))
+
+fn(arg = fn(arg = fn(
+  arg
+)))

--- a/crates/roughly/tests/snapshots/test_format__call-2.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-2.snap
@@ -1,8 +1,5 @@
 ---
-source: src/format.rs
-expression: "fmt(indoc! { r#\"\n            list  (a = 1,\n             b= 2L)\n        \"# })"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc! {r#\"\n        fn(arg1, arg2)\n    \"#}).unwrap()"
 ---
-list(
-  a = 1,
-  b = 2L
-)
+fn(arg1, arg2)

--- a/crates/roughly/tests/snapshots/test_format__call-3.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-3.snap
@@ -1,13 +1,5 @@
 ---
 source: crates/roughly/tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n        list  (\n            # foo\n            a = 1, #bar\n            b= 2L) #baz\n\n    \tfn(arg1, function() { # 1\n            body # 2\n        }) # 3\n    \"#}).unwrap()"
+expression: "format_str(indoc! {r#\"\n        fn(a = 1, b = 2, c = 3)\n    \"#}).unwrap()"
 ---
-list(
-  # foo
-  a = 1, # bar
-  b = 2L
-) # baz
-
-fn(arg1, function() { # 1
-  body # 2
-}) # 3
+fn(a = 1, b = 2, c = 3)

--- a/crates/roughly/tests/snapshots/test_format__call-3.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-3.snap
@@ -1,9 +1,13 @@
 ---
-source: src/format.rs
-expression: "fmt(indoc!\n{\n    r#\"\n            list  (\n                # foo\n                a = 1, #bar\n                b= 2L) #baz\n        \"#\n})"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n        list  (\n            # foo\n            a = 1, #bar\n            b= 2L) #baz\n\n    \tfn(arg1, function() { # 1\n            body # 2\n        }) # 3\n    \"#}).unwrap()"
 ---
 list(
   # foo
   a = 1, # bar
   b = 2L
 ) # baz
+
+fn(arg1, function() { # 1
+  body # 2
+}) # 3

--- a/crates/roughly/tests/snapshots/test_format__call-4.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-4.snap
@@ -1,23 +1,5 @@
 ---
-source: tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n        foo({ bar; baz })\n        foo({ bar;\n        baz })\n        foo({ bar;\n        baz }, qux)\n        foo(qux = { bar;\n        baz }, qux)\n    \"#}).unwrap()"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc! {r#\"\n        fn(1, b = 2, c = 3)\n    \"#}).unwrap()"
 ---
-foo({ bar; baz })
-foo({
-  bar
-  baz
-})
-foo(
-  {
-    bar
-    baz
-  },
-  qux
-)
-foo(
-  qux = {
-    bar
-    baz
-  },
-  qux
-)
+fn(1, b = 2, c = 3)

--- a/crates/roughly/tests/snapshots/test_format__call-5.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-5.snap
@@ -1,11 +1,5 @@
 ---
-source: tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n    \tfn( # (\n        \t# 1\n            arg1 # arg1\n            , # ,\n            arg2 # arg2\n            # 2\n        ) # )\n    \"#}).unwrap()"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc! {r#\"\n        fn (1 ,b=2 ,c=3   )\n    \"#}).unwrap()"
 ---
-fn( # (
-  # 1
-  arg1 # arg1
-  , # ,
-  arg2 # arg2
-  # 2
-) # )
+fn(1, b = 2, c = 3)

--- a/crates/roughly/tests/snapshots/test_format__call-6.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-6.snap
@@ -1,15 +1,9 @@
 ---
 source: crates/roughly/tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n    \tfn(arg)\n\n    \tfn(arg\n        )\n\n    \tfn(\n        arg)\n\n    \tfn(\n        arg\n        )\n    \"#}).unwrap()"
+expression: "format_str(indoc!\n{r#\"\n        fn(\n            1,\n        b=2,\n            c=3\n        )\n    \"#}).unwrap()"
 ---
-fn(arg)
-
-fn(arg)
-
 fn(
-  arg
-)
-
-fn(
-  arg
+  1,
+  b = 2,
+  c = 3
 )

--- a/crates/roughly/tests/snapshots/test_format__call-6.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-6.snap
@@ -1,9 +1,15 @@
 ---
-source: tests/test_format.rs
-expression: "format_str(indoc!\n{\n    r#\"\n    \tfn( # (\n        \t# 1\n            argument # argument\n            # 2\n        ) # )\n    \"#\n}).unwrap()"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn(arg)\n\n    \tfn(arg\n        )\n\n    \tfn(\n        arg)\n\n    \tfn(\n        arg\n        )\n    \"#}).unwrap()"
 ---
-fn( # (
-  # 1
-  argument # argument
-  # 2
-) # )
+fn(arg)
+
+fn(arg)
+
+fn(
+  arg
+)
+
+fn(
+  arg
+)

--- a/crates/roughly/tests/snapshots/test_format__call-7.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-7.snap
@@ -1,0 +1,15 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn({ body })\n\n    \tfn({ body }\n        )\n\n    \tfn(\n        { body })\n\n    \tfn(\n        { body }\n        )\n    \"#}).unwrap()"
+---
+fn({ body })
+
+fn({ body })
+
+fn(
+  { body }
+)
+
+fn(
+  { body }
+)

--- a/crates/roughly/tests/snapshots/test_format__call-7.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-7.snap
@@ -1,15 +1,9 @@
 ---
 source: crates/roughly/tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n    \tfn({ body })\n\n    \tfn({ body }\n        )\n\n    \tfn(\n        { body })\n\n    \tfn(\n        { body }\n        )\n    \"#}).unwrap()"
+expression: "format_str(indoc!\n{r#\"\n        fn(1\n        ,b=2,\n        c=3)\n    \"#}).unwrap()"
 ---
-fn({ body })
-
-fn({ body })
-
 fn(
-  { body }
-)
-
-fn(
-  { body }
+  1,
+  b = 2,
+  c = 3
 )

--- a/crates/roughly/tests/snapshots/test_format__call-8.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-8.snap
@@ -1,0 +1,23 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn({\n            body\n        })\n\n    \tfn({\n            body\n        }\n        )\n\n    \tfn(\n        {\n            body\n        })\n\n    \tfn(\n        {\n            body\n        }\n        )\n    \"#}).unwrap()"
+---
+fn({
+  body
+})
+
+fn({
+  body
+})
+
+fn(
+  {
+    body
+  }
+)
+
+fn(
+  {
+    body
+  }
+)

--- a/crates/roughly/tests/snapshots/test_format__call-8.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-8.snap
@@ -1,23 +1,13 @@
 ---
 source: crates/roughly/tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n    \tfn({\n            body\n        })\n\n    \tfn({\n            body\n        }\n        )\n\n    \tfn(\n        {\n            body\n        })\n\n    \tfn(\n        {\n            body\n        }\n        )\n    \"#}).unwrap()"
+expression: "format_str(indoc!\n{r#\"\n        fn  ( # 1\n            # 2\n            a = 1, # 3\n            b= 2) # 4\n\n    \tfn(arg1, function() { # 1\n            body # 2\n        }) # 3\n    \"#}).unwrap()"
 ---
-fn({
-  body
-})
+fn( # 1
+  # 2
+  a = 1, # 3
+  b = 2
+) # 4
 
-fn({
-  body
-})
-
-fn(
-  {
-    body
-  }
-)
-
-fn(
-  {
-    body
-  }
-)
+fn(arg1, function() { # 1
+  body # 2
+}) # 3

--- a/crates/roughly/tests/snapshots/test_format__call-9.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-9.snap
@@ -1,17 +1,11 @@
 ---
 source: crates/roughly/tests/test_format.rs
-expression: "format_str(indoc!\n{r#\"\n    \tfn(arg1, fn(\n        ))\n\n    \tfn(arg1, {\n            body\n        })\n\n    \tfn(arg1, function() {\n            body\n        })\n\n    \tfn(arg1, if(condition) {\n            body\n        })\n    \"#}).unwrap()"
+expression: "format_str(indoc!\n{r#\"\n    \tfn( # (\n        \t# 1\n            arg1 # arg1\n            , # ,\n            arg2 # arg2\n            # 2\n        ) # )\n    \"#}).unwrap()"
 ---
-fn(arg1, fn())
-
-fn(arg1, {
-  body
-})
-
-fn(arg1, function() {
-  body
-})
-
-fn(arg1, if (condition) {
-  body
-})
+fn( # (
+  # 1
+  arg1 # arg1
+  , # ,
+  arg2 # arg2
+  # 2
+) # )

--- a/crates/roughly/tests/snapshots/test_format__call-9.snap
+++ b/crates/roughly/tests/snapshots/test_format__call-9.snap
@@ -1,0 +1,17 @@
+---
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n    \tfn(arg1, fn(\n        ))\n\n    \tfn(arg1, {\n            body\n        })\n\n    \tfn(arg1, function() {\n            body\n        })\n\n    \tfn(arg1, if(condition) {\n            body\n        })\n    \"#}).unwrap()"
+---
+fn(arg1, fn())
+
+fn(arg1, {
+  body
+})
+
+fn(arg1, function() {
+  body
+})
+
+fn(arg1, if (condition) {
+  body
+})

--- a/crates/roughly/tests/snapshots/test_format__call.snap
+++ b/crates/roughly/tests/snapshots/test_format__call.snap
@@ -1,5 +1,5 @@
 ---
-source: src/format.rs
-expression: "fmt(indoc! { r#\"\n            list  (a = 1, b= 2L ,c =3i  )\n        \"# })"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc! {r#\"\n        fn(arg)\n    \"#}).unwrap()"
 ---
-list(a = 1, b = 2L, c = 3i)
+fn(arg)

--- a/crates/roughly/tests/snapshots/test_format__chained_extract_operators.snap
+++ b/crates/roughly/tests/snapshots/test_format__chained_extract_operators.snap
@@ -1,6 +1,6 @@
 ---
-source: tests/test_format.rs
-expression: "format_str(indoc!\n{\n    r#\"\n        foo$\n            bar(a)$\n            baz(a,b)\n\n        (foo\n        )$\n            bar(a\n            )$\n            baz(a,b)$\n    \"#\n}).unwrap()"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n        foo$\n            bar(a)$\n            baz(a,b)\n\n        (foo\n        )$\n            bar(a\n            )$\n            baz(a,b)$\n    \"#}).unwrap()"
 ---
 foo$
   bar(a)$
@@ -9,7 +9,5 @@ foo$
 (
   foo
 )$
-  bar(
-    a
-  )$
+  bar(a)$
   baz(a, b)$

--- a/crates/roughly/tests/snapshots/test_format__string-2.snap
+++ b/crates/roughly/tests/snapshots/test_format__string-2.snap
@@ -1,10 +1,8 @@
 ---
-source: src/format.rs
-expression: "format_str(indoc!\n{\n    r#\"\n            \"foo\n                bar\"\n            foo(\"foo\n                bar\")\n        \"#\n}).unwrap()"
+source: crates/roughly/tests/test_format.rs
+expression: "format_str(indoc!\n{r#\"\n        \"foo\n            bar\"\n        foo(\"foo\n            bar\")\n    \"#}).unwrap()"
 ---
 "foo
     bar"
-foo(
-  "foo
-    bar"
-)
+foo("foo
+    bar")

--- a/crates/roughly/tests/test_format.rs
+++ b/crates/roughly/tests/test_format.rs
@@ -190,34 +190,56 @@ fn braced_expression() {
 
 #[test]
 fn call() {
+    // single argument
     assert_fmt! {r#"
-        list  (a = 1, b= 2L ,c =3i  )
+        fn(arg)
+    "#};
+
+    // multiple arguments
+    assert_fmt! {r#"
+        fn(arg1, arg2)
+    "#};
+
+    // multiple named arguments
+    assert_fmt! {r#"
+        fn(a = 1, b = 2, c = 3)
+    "#};
+
+    // mixed positional and named arguments
+    assert_fmt! {r#"
+        fn(1, b = 2, c = 3)
+    "#};
+
+    // spacing:
+    assert_fmt! {r#"
+        fn (1 ,b=2 ,c=3   )
     "#};
     assert_fmt! {r#"
-        list  (a = 1,
-         b= 2L)
+        fn(
+            1,
+        b=2,
+            c=3
+        )
     "#};
     assert_fmt! {r#"
-        list  (
-            # foo
-            a = 1, #bar
-            b= 2L) #baz
+        fn(1
+        ,b=2,
+        c=3)
+    "#};
+
+    // comments
+    assert_fmt! {r#"
+        fn  ( # 1
+            # 2
+            a = 1, # 3
+            b= 2) # 4
 
     	fn(arg1, function() { # 1
             body # 2
         }) # 3
     "#};
-    assert_fmt! {r#"
-        foo({ bar; baz })
-        foo({ bar;
-        baz })
-        foo({ bar;
-        baz }, qux)
-        foo(qux = { bar;
-        baz }, qux)
-    "#};
 
-    // all comment positions
+    // comments: all positions
     assert_fmt! {r#"
     	fn( # (
         	# 1
@@ -281,6 +303,17 @@ fn call() {
         )
     "#};
 
+    // hugging: more complex blocks
+    assert_fmt! {r#"
+        fn({ body; body })
+        fn({ body;
+        body })
+        fn({ body;
+        body }, arg)
+        fn(a = { body;
+        body }, arg)
+    "#};
+
     // hugging: multiple arguments
     assert_fmt! {r#"
     	fn(arg1, fn(
@@ -290,11 +323,11 @@ fn call() {
             body
         })
 
-    	fn(arg1, function() {
+    	fn(arg1, arg2 = value, function() {
             body
         })
 
-    	fn(arg1, if(condition) {
+    	fn(arg1, arg2 = value, if(condition) {
             body
         })
     "#};

--- a/crates/roughly/tests/test_format.rs
+++ b/crates/roughly/tests/test_format.rs
@@ -210,7 +210,7 @@ fn call() {
         fn(1, b = 2, c = 3)
     "#};
 
-    // spacing:
+    // whitespace
     assert_fmt! {r#"
         fn (1 ,b=2 ,c=3   )
     "#};

--- a/crates/roughly/tests/test_format.rs
+++ b/crates/roughly/tests/test_format.rs
@@ -319,6 +319,9 @@ fn call() {
     	fn(arg1, fn(
         ))
 
+    	fn(arg1, arg2 = fn(
+        ))
+
     	fn(arg1, {
             body
         })

--- a/crates/roughly/tests/test_format.rs
+++ b/crates/roughly/tests/test_format.rs
@@ -334,6 +334,27 @@ fn call() {
             body
         })
     "#};
+
+    // hugging: nested
+    assert_fmt! {r#"
+    	fn(fn(arg
+        ))
+
+    	fn(fn(
+        arg))
+
+    	fn(fn(
+        arg
+        ))
+
+    	fn(fn(fn(
+            arg
+        )))
+
+    	fn(arg = fn(arg =fn(
+            arg
+        )))
+    "#};
 }
 
 #[test]

--- a/crates/roughly/tests/test_format.rs
+++ b/crates/roughly/tests/test_format.rs
@@ -202,6 +202,10 @@ fn call() {
             # foo
             a = 1, #bar
             b= 2L) #baz
+
+    	fn(arg1, function() { # 1
+            body # 2
+        }) # 3
     "#};
     assert_fmt! {r#"
         foo({ bar; baz })
@@ -222,6 +226,77 @@ fn call() {
             arg2 # arg2
             # 2
         ) # )
+    "#};
+
+    // hugging: single line args
+    assert_fmt! {r#"
+    	fn(arg)
+
+    	fn(arg
+        )
+
+    	fn(
+        arg)
+
+    	fn(
+        arg
+        )
+    "#};
+
+    // hugging: single line block
+    assert_fmt! {r#"
+    	fn({ body })
+
+    	fn({ body }
+        )
+
+    	fn(
+        { body })
+
+    	fn(
+        { body }
+        )
+    "#};
+
+    // hugging: multi line block
+    assert_fmt! {r#"
+    	fn({
+            body
+        })
+
+    	fn({
+            body
+        }
+        )
+
+    	fn(
+        {
+            body
+        })
+
+    	fn(
+        {
+            body
+        }
+        )
+    "#};
+
+    // hugging: multiple arguments
+    assert_fmt! {r#"
+    	fn(arg1, fn(
+        ))
+
+    	fn(arg1, {
+            body
+        })
+
+    	fn(arg1, function() {
+            body
+        })
+
+    	fn(arg1, if(condition) {
+            body
+        })
     "#};
 }
 


### PR DESCRIPTION
Allow hugging if all arguments start in same row:

```R
fn(arg1, function() {
    body
})
```